### PR TITLE
Updated install to recognise Stretch 9.10 & 9.11

### DIFF
--- a/install
+++ b/install
@@ -45,7 +45,7 @@ case "$RELEASE" in
     pkgdeplist=${pkgdeplist10[@]}
     flotilla_binary="flotilla-stretch"
     ;;
-"9.0" | "9.1" | "9.2" | "9.3" | "9.4" | "9.5" | "9.6" | "9.7" | "9.8" | "9.9")
+"9.0" | "9.1" | "9.2" | "9.3" | "9.4" | "9.5" | "9.6" | "9.7" | "9.8" | "9.9" | "9.10" | "9.11")
     printf "Detected Raspbian Stretch...\n"
     pkgdeplist=${pkgdeplist9[@]}
     flotilla_binary="flotilla-stretch"


### PR DESCRIPTION
I needed to add 9.11 to the install file to get it to work on my Pi 2B running the latest version of Stretch.

I thought it would help to submit a PR with the changes.